### PR TITLE
fix: make the dashboard work when opened through a tunnel

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -14,7 +14,7 @@ import {
 import { autoResumeStartup } from "./agent.js";
 import { failStaleRunningJobs } from "./db.js";
 import { addSseClient } from "./events.js";
-import { HttpError, isLocalRequest, secretEquals } from "./util.js";
+import { HttpError, cookieValue, isLocalRequest, secretEquals } from "./util.js";
 import { isKnownUploadToken } from "./routes/uploadSession.js";
 
 import healthRouter from "./routes/health.js";
@@ -81,19 +81,6 @@ app.use((req: Request, res: Response, next: NextFunction) => {
 });
 
 // ============ Xác thực (đặt TRƯỚC mọi router) ============
-
-/** Lấy cookie theo tên từ header Cookie (không kéo thêm dependency cookie-parser) */
-function cookieValue(req: Request, name: string): string {
-  const raw = req.headers.cookie;
-  if (!raw) return "";
-  for (const part of raw.split(";")) {
-    const eq = part.indexOf("=");
-    if (eq < 0) continue;
-    if (part.slice(0, eq).trim() !== name) continue;
-    return decodeURIComponent(part.slice(eq + 1).trim());
-  }
-  return "";
-}
 
 function queryString(value: unknown): string {
   return typeof value === "string" ? value : "";

--- a/apps/server/src/routes/assets.ts
+++ b/apps/server/src/routes/assets.ts
@@ -11,6 +11,7 @@ import {
   HttpError,
   ensureDir,
   fileInfoOf,
+  hasMasterToken,
   isLocalRequest,
   listFilesRecursive,
   moveFile,
@@ -220,7 +221,9 @@ router.post("/", uploadProgress, upload.single("file"), (req, res) => {
     // Token lấy từ field `token` (client append TRƯỚC file) hoặc query `?k=`;
     // do modal QR tạo, ĐÓNG modal là thu hồi ngay → link hết hiệu lực.
     // Sai/thiếu → 403, file tạm đã nhận bị xóa ở catch bên dưới.
-    if (!isLocalRequest(req)) {
+    // Dashboard mở qua tunnel mang TOKEN CHÍNH - đã là chủ máy, không phải
+    // bắt quét thêm mã QR (token chính vốn mở được cả agent lẫn xóa project).
+    if (!isLocalRequest(req) && !hasMasterToken(req)) {
       const token = qs(body.token) || qs(req.query.k);
       // Token gắn với đúng project khi scope=project; scope khác chỉ cần token
       // của một phiên còn hiệu lực (phiên nào cũng do người dùng vừa mở QR).

--- a/apps/server/src/util.ts
+++ b/apps/server/src/util.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { spawn, type ChildProcess } from "node:child_process";
 import type { Request } from "express";
-import { childEnv, repoRoot } from "./config.js";
+import { apiToken, childEnv, repoRoot } from "./config.js";
 
 /** Lỗi HTTP có mã - error handler ở index.ts sẽ trả { error: { code, message } } */
 export class HttpError extends Error {
@@ -54,6 +54,36 @@ export function secretEquals(a: string, b: string): boolean {
   const bufB = Buffer.from(b, "utf8");
   if (bufA.length !== bufB.length) return false;
   return crypto.timingSafeEqual(bufA, bufB);
+}
+
+/** Lấy cookie theo tên từ header Cookie (không kéo thêm dependency cookie-parser) */
+export function cookieValue(req: Request, name: string): string {
+  const raw = req.headers.cookie;
+  if (!raw) return "";
+  for (const part of raw.split(";")) {
+    const eq = part.indexOf("=");
+    if (eq < 0) continue;
+    if (part.slice(0, eq).trim() !== name) continue;
+    return decodeURIComponent(part.slice(eq + 1).trim());
+  }
+  return "";
+}
+
+/**
+ * Request có mang TOKEN CHÍNH của dashboard hay không - token này mở toàn bộ
+ * API, nên chỗ nào đang lấy "đến từ chính máy chủ" làm bằng chứng tin cậy thì
+ * cũng phải chấp nhận nó: dashboard mở qua tunnel là truy cập từ xa nhưng vẫn
+ * là chủ máy. Token đi bằng header, cookie hoặc query `?t=` (giống middleware
+ * xác thực chung ở index.ts).
+ */
+export function hasMasterToken(req: Request): boolean {
+  const token = apiToken();
+  if (!token) return false;
+  const header = req.headers["x-aiev-token"];
+  if (typeof header === "string" && secretEquals(header, token)) return true;
+  if (secretEquals(cookieValue(req, "aiev_token"), token)) return true;
+  const t = req.query?.t;
+  return typeof t === "string" && secretEquals(t, token);
 }
 
 const KEBAB_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -20,9 +20,14 @@ const nextConfig: NextConfig = {
     position: "bottom-right",
   },
   experimental: {
-    // Proxy rewrite mặc định timeout 30s — video lớn (media/stream) cần lâu hơn.
-    // Upload file lớn đã đi thẳng backend (serverOrigin trong lib/api.ts), đây là lớp dự phòng.
+    // Proxy rewrite mặc định timeout 30s - video lớn (media/stream) cần lâu hơn.
+    // Trên LAN upload đi thẳng backend, nhưng qua domain công cộng thì mọi thứ
+    // kể cả upload đều chui qua đây, nên hai mốc dưới là đường đi chính.
     proxyTimeout: 10 * 60 * 1000,
+    // Proxy mặc định CẮT body ở 10MB: phần vượt bị bỏ, multer chờ hết stream
+    // rồi timeout -> upload video qua domain công cộng chết với lỗi 500 khó hiểu.
+    // Nới bằng mức multer đang cho phép (2GB) để một chỗ không âm thầm chặn chỗ kia.
+    proxyClientMaxBodySize: 2 * 1024 * 1024 * 1024,
   },
   async rewrites() {
     return [

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -704,34 +704,40 @@ export type ImageGenStep = "all" | "background" | "compose";
 // ============ Error & core ============
 
 /**
+ * Truy cập đang ở cùng mạng với máy chủ hay không - quyết định có gọi thẳng
+ * cổng backend được không. Tunnel/domain công cộng chỉ mở duy nhất cổng web.
+ */
+function isLocalNetworkHost(host: string): boolean {
+  return (
+    host === "localhost" ||
+    /^127\./.test(host) ||
+    /^(192\.168\.|10\.|172\.(1[6-9]|2\d|3[01])\.|100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\.)/.test(
+      host
+    )
+  );
+}
+
+/**
  * Origin của backend - dùng cho upload file lớn: gọi THẲNG server (CORS đã mở),
  * không qua rewrite proxy của Next (proxy có timeout ~30s, file video lớn sẽ chết).
+ *
+ * Qua domain công cộng (Cloudflare Tunnel chỉ đưa ra cổng web) thì cổng backend
+ * KHÔNG tồn tại trên domain đó, và trang https gọi http còn bị chặn mixed
+ * content - nên đi same-origin qua proxy /api của Next (proxyTimeout 10 phút).
  */
 export function serverOrigin(): string {
   if (typeof window === "undefined") return "http://localhost:6869";
+  if (!isLocalNetworkHost(window.location.hostname)) return window.location.origin;
   const port = process.env.NEXT_PUBLIC_SERVER_PORT || "6869";
   return `http://${window.location.hostname}:${port}`;
 }
 
 /**
- * Origin để UPLOAD file từ trang mobile /m - tự thích ứng cách truy cập:
- * - LAN/localhost (localhost, 127.x, IP private 192.168/10./172.16-31,
- *   Tailscale 100.64-127): gọi THẲNG backend 6869 (serverOrigin) - né proxy
- *   Next vì request dài dễ dính buffering/timeout với file video lớn.
- * - Domain qua tunnel (vd Cloudflare Tunnel https://aiev.noti.vn →
- *   localhost:6868): cổng 6869 KHÔNG tồn tại trên domain đó → upload
- *   same-origin qua đường proxy /api của Next (đã set proxyTimeout 10 phút).
+ * Origin để UPLOAD file từ trang mobile /m. Giữ tên riêng cho rõ ý ở nơi gọi;
+ * cách chọn LAN hay tunnel nay nằm hết trong serverOrigin().
  */
 export function uploadOrigin(): string {
-  if (typeof window === "undefined") return "http://localhost:6869";
-  const host = window.location.hostname;
-  const isLocalNetwork =
-    host === "localhost" ||
-    /^127\./.test(host) ||
-    /^(192\.168\.|10\.|172\.(1[6-9]|2\d|3[01])\.|100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\.)/.test(
-      host
-    );
-  return isLocalNetwork ? serverOrigin() : window.location.origin;
+  return serverOrigin();
 }
 
 export class ApiError extends Error {

--- a/docs/API.md
+++ b/docs/API.md
@@ -101,7 +101,9 @@ POST   /api/upload-session          { projectId } → 201 { token: "ut_…", exp
 DELETE /api/upload-session/:token   → 204                                              // đóng modal QR — thu hồi ngay, idempotent
 ```
 
-URL/QR mang token qua query `?k=`; trang `/m` gửi lại qua field `token` (append TRƯỚC `file`). POST `/api/assets` scope `project` từ máy KHÁC máy chủ (điện thoại LAN/tunnel — không phải loopback, hoặc có `x-forwarded-for`) bắt buộc token hợp lệ đúng project — sai/thiếu → `403 UPLOAD_TOKEN_INVALID` ("Link upload đã hết hạn — mở lại mã QR trên máy tính.").
+URL/QR mang token qua query `?k=`; trang `/m` gửi lại qua field `token` (append TRƯỚC `file`). POST `/api/assets` từ máy KHÁC máy chủ (điện thoại LAN/tunnel - không phải loopback, hoặc có `x-forwarded-for`) bắt buộc token phiên upload hợp lệ, đúng project khi scope là `project` - sai/thiếu → `403 UPLOAD_TOKEN_INVALID` ("Link upload đã hết hạn — mở lại mã QR trên máy tính.").
+
+Ngoại lệ: request mang `AIEV_API_TOKEN` (header `x-aiev-token`, cookie `aiev_token` hoặc query `?t=`) được miễn token phiên QR. Đó là dashboard của chính chủ máy mở qua tunnel; token này vốn đã mở được cả chạy agent lẫn xóa project nên đòi thêm mã QR không thêm an toàn, chỉ chặn nhầm.
 
 **Đóng modal QR = đóng hết.** Thu hồi token, và nếu đường Internet được bật TỪ CHÍNH modal đó thì
 tắt luôn tunnel (xem [Cloudflare Tunnel](#cloudflare-tunnel-card-trên-trang-connections)). Tab bị


### PR DESCRIPTION
## Tóm tắt

Ba lỗi độc lập khiến dashboard **không dùng được khi mở qua Cloudflare Tunnel**. Cả ba chỉ lộ ra khi trình duyệt không chạy trên chính máy đang chạy server, nên bản chạy local hoàn toàn bình thường.

Repo đã hỗ trợ sẵn kịch bản này (`TUNNEL_DOMAIN` trong `.env`, luồng nạp token qua `?t=`, `uploadOrigin()` cho trang `/m`), nên đây là hoàn thiện thứ đã có chứ không phải tính năng mới.

Phát hiện khi triển khai AIEV lên một server Ubuntu 24.04, truy cập qua Cloudflare Tunnel. Mọi kết quả bên dưới đều đo trên bản chạy thật, không phải suy luận.

## Lỗi 1: `serverOrigin()` trỏ vào cổng không tồn tại trên domain

**Hiện tượng:** upload báo `Không kết nối được backend (port 6869). Kiểm tra server đã chạy chưa.`

**Nguyên nhân** (`apps/web/src/lib/api.ts`):

```ts
return `http://${window.location.hostname}:${port}`;   // http://video.example.com:6869
```

Tunnel chỉ publish cổng web. Cổng backend không tồn tại trên domain đó, và trang `https` gọi `http` còn bị chặn mixed content.

**Ảnh hưởng 10 chỗ gọi:** upload asset, SFX, nhạc, logo và font của Style Design, ảnh nền Images Project, nhân bản giọng, nguồn Dịch video, tạo Skill, và bước bootstrap token.

Repo **đã có** `uploadOrigin()` giải đúng bài này, nhưng chỉ trang mobile `/m` gọi nó.

**Sửa:** chuyển phép chọn vào `serverOrigin()` (host không thuộc localhost / 127.x / LAN riêng / Tailscale `100.64-127.x` thì trả `window.location.origin`), `uploadOrigin()` gọi lại nó. Hết trùng logic, mọi chỗ gọi được lợi cùng lúc.

Trên LAN và localhost hành vi **không đổi**: vẫn gọi thẳng 6869, vẫn né proxy như thiết kế cũ.

## Lỗi 2: `POST /api/assets` bắt dashboard quét mã QR

**Hiện tượng:** sau khi sửa lỗi 1, upload trả `403 UPLOAD_TOKEN_INVALID` với thông báo "Link upload đã hết hạn - mở lại mã QR trên máy tính", trong khi người dùng đang ngồi ở dashboard máy tính, chưa hề mở modal QR nào.

**Nguyên nhân** (`apps/server/src/routes/assets.ts`):

```ts
if (!isLocalRequest(req)) {   // qua tunnel thì dashboard cũng không phải loopback
```

Điều kiện chỉ nghĩ tới ca điện thoại. Dashboard qua tunnel là truy cập từ xa, nhưng nó cầm `AIEV_API_TOKEN`, thứ vốn đã cho phép chạy agent và xóa project.

**Sửa:** thêm `hasMasterToken(req)` và miễn token phiên QR cho request mang nó.

**Về mặt bảo mật đây không phải nới lỏng:** middleware xác thực chung ở `index.ts` đã chặn từ trước, request chỉ tới được route này khi (a) là loopback, (b) mang master token, hoặc (c) mang `?k=` hợp lệ. Nghĩa là request đi qua nhánh mới chắc chắn **đã** được xác thực đầy đủ. Bắt thêm mã QR chồng lên một credential vốn mạnh hơn thì không tăng an toàn, chỉ chặn nhầm chủ máy.

**Luồng QR giữ nguyên:** điện thoại không có master token nên vẫn rơi xuống nhánh cũ, vẫn bắt buộc `?k=` hợp lệ và đúng project khi `scope=project`.

Nếu maintainer muốn giữ nguyên hành vi cũ, phần này tách riêng được, hai lỗi kia vẫn đứng độc lập.

## Lỗi 3: proxy của Next cắt body ở 10MB

**Hiện tượng:** file text nhỏ upload được, video thì `HTTP 500`.

**Log:**

```
[web]    Request body exceeded 10MB for /api/assets. Only the first 10MB will be available
[server] Unhandled error: Error: Request aborted   (multer)
[web]    Failed to proxy http://localhost:6869/api/assets  ECONNRESET
```

**Nguyên nhân:** sau lỗi 1, upload qua domain công cộng đi bằng proxy của Next, mà proxy mặc định cắt body ở 10MB. Phần vượt bị bỏ, multer ngồi chờ hết stream, 45s sau bộ đếm stall hủy request. Người dùng chỉ thấy 500, không có manh mối gì.

`next.config.ts` đã đặt `proxyTimeout` 10 phút nên đã nghĩ tới file lớn, chỉ thiếu vế kích thước.

**Sửa:** `proxyClientMaxBodySize` bằng đúng trần 2GB mà multer đang cho phép, để một bên không âm thầm chặn bên kia.

## Đo thực tế

| File | Đường đi | Kết quả |
|---|---|---|
| 17 B | Cloudflare Tunnel | 201 |
| 50 MB | Cloudflare Tunnel | **201, 3.7s** |
| 150 MB | Cloudflare Tunnel | 413 do **Cloudflare** trả, 0.4s |
| 150 MB | LAN/Tailscale, cổng 6869 | **201, 255s** |

Cái 413 là trần 100MB của gói Cloudflare Free/Pro, request chưa từng chạm tới server. Ngoài tầm sửa của repo, nhưng đáng biết: người dùng nên upload video lớn qua LAN hoặc Tailscale, đường đó fix này vẫn giữ nguyên là gọi thẳng 6869.

Kiểm tra xác thực còn nguyên, đo qua tunnel:

| Ca | Kết quả |
|---|---|
| Upload có master token | 201 |
| Upload không token | 401 |
| Upload token sai | 401 |
| `GET /api/health` từ ngoài | không lộ `apiToken` (chỉ loopback mới được trả) |

## Áp dụng cho ai

Bất kỳ ai chạy AIEV sau reverse proxy hoặc tunnel: Cloudflare Tunnel, ngrok, Tailscale Funnel, nginx trước cổng 6868. Người chạy `localhost` hoặc trong LAN **không bị ảnh hưởng**, mọi nhánh cũ giữ nguyên.

## Kiểm thử

```
npm run typecheck    # sạch
npm run build        # sạch
```

Ngoài ra đã chạy bản deploy thật trong nhiều giờ: upload asset, mở dashboard qua hai hostname khác nhau, provider Claude (subscription) và Gemini đều nhận.

Không thêm dependency nào. `docs/API.md` đã cập nhật theo đúng yêu cầu trong CONTRIBUTING vì điều kiện xác thực của `POST /api/assets` có đổi.

## Ghi chú

`cookieValue` được chuyển từ `index.ts` sang `util.ts` vì `hasMasterToken` cần nó. Chuyển nguyên hàm, không sửa nội dung, `index.ts` import về dùng thay vì giữ bản thứ hai.

Không format lại file nào, không đụng `package-lock.json`.
