### PR TITLE
fix(security): cap sfx description length and block remote imports upload

### DIFF
--- a/apps/server/src/routes/assets.ts
+++ b/apps/server/src/routes/assets.ts
@@ -222,13 +222,16 @@ router.post("/", uploadProgress, upload.single("file"), (req, res) => {
     // Sai/thiếu → 403, file tạm đã nhận bị xóa ở catch bên dưới.
     if (!isLocalRequest(req)) {
       const token = qs(body.token) || qs(req.query.k);
-      // Token gắn với đúng project khi scope=project; scope khác chỉ cần token
-      // của một phiên còn hiệu lực (phiên nào cũng do người dùng vừa mở QR).
-      const ok =
-        scope === "project"
-          ? isValidUploadToken(token, projectId ?? "")
-          : isKnownUploadToken(token);
-      if (!ok) {
+      // imports/ là thư mục dùng chung — không cho QR token remote ghi vào;
+      // upload từ điện thoại chỉ được dùng scope=project (gắn đúng project).
+      if (scope !== "project") {
+        throw new HttpError(
+          403,
+          "UPLOAD_TOKEN_INVALID",
+          "Upload vào thư mục dùng chung chỉ được từ máy tính."
+        );
+      }
+      if (!isValidUploadToken(token, projectId ?? "")) {
         throw new HttpError(
           403,
           "UPLOAD_TOKEN_INVALID",

--- a/apps/server/src/routes/sfx.ts
+++ b/apps/server/src/routes/sfx.ts
@@ -166,7 +166,7 @@ router.patch("/:file", (req, res) => {
     if (typeof body.description !== "string") {
       throw new HttpError(400, "INVALID_DESCRIPTION", "description phải là string");
     }
-    entry.description = body.description;
+    entry.description = body.description.trim().slice(0, 2000);
   }
 
   if ("tags" in body) {


### PR DESCRIPTION
## Summary

- **sfx.ts**: `description` field in `PATCH /api/sfx/:file` had no length cap while `source` (500 chars) and `license` (60 chars) were both bounded. An attacker can write up to ~20 MB per call into `library.json`, degrading every subsequent `readLibrary()` parse.

- **assets.ts**: `POST /api/assets` with `scope=imports` from a non-local request only required `isKnownUploadToken()` — any live QR token for *any* project was enough to write to the shared `imports/` directory. Remote QR uploads are now restricted to `scope=project` only.

## Changes

| File | Change |
|------|--------|
| `apps/server/src/routes/sfx.ts` | Add `.trim().slice(0, 2000)` to `description` — consistent with how `source`/`license` are bounded |
| `apps/server/src/routes/assets.ts` | Block non-project scope for remote QR token uploads; `imports/` requires local access |

## Test plan

- [ ] `PATCH /api/sfx/<file>` with 10 MB description → saved value ≤ 2000 chars
- [ ] `POST /api/assets?k=<valid_token>` with `scope=imports` from non-local → 403
- [ ] `POST /api/assets?k=<valid_token>` with `scope=project&projectId=<id>` from phone → works normally

Giap & Claude Code